### PR TITLE
Revert to local_routing. Enable unstable zenoh features.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "bincode",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "flume",
  "json5",
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -3133,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "aes 0.8.1",
  "hmac 0.12.1",
@@ -3146,7 +3146,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3165,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3203,7 +3203,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3218,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "libloading",
  "log",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "log",
  "uhlc",
@@ -3308,7 +3308,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "hex",
  "itertools",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3336,7 +3336,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh?branch=api-changes#861378388246253927fc936a4ab8f3af6edf3d7a"
+source = "git+https://github.com/eclipse-zenoh/zenoh?branch=local-routing#84faacb51e41dae8f5560dcfe12aa9fff57b9100"
 dependencies = [
  "async-std",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ name = "zplugin_webserver"
 crate-type = ["cdylib"]
 
 [dependencies]
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "api-changes" }
-zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "api-changes" }
-zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "api-changes", default-features = false }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing", features = ["unstable"] }
+zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing" }
+zenoh-plugin-trait = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "local-routing", default-features = false }
 anyhow = "1.0.59"
 async-std = "=1.12.0"
 futures = "0.3.12"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,15 +81,8 @@ zenoh_plugin_trait::declare_plugin!(WebServerPlugin);
 async fn run(runtime: Runtime, conf: Config) {
     debug!("WebServer plugin {}", LONG_VERSION.as_str());
 
-    let zenoh = match zenoh::init(runtime).res().await {
-        Ok(session) => Arc::new(session),
-        Err(e) => {
-            log::error!("Unable to init zenoh session for WebServer plugin : {}", e);
-            return;
-        }
-    };
-
-    let mut app = Server::with_state(zenoh);
+    let zenoh = Session::init(runtime, true, vec![], vec![]).res().await;
+    let mut app = Server::with_state(Arc::new(zenoh));
 
     app.at("*").get(handle_request);
 


### PR DESCRIPTION
Sister PR: https://github.com/eclipse-zenoh/zenoh/pull/320.

This PR is marked as draft since the zenoh branch in `Cargo.toml` should point to `api-changes` instead of `local-routing`.
Once the sister PR is merged, the `api-changes` branch will be configured in `Cargo.toml` and this PR will be ready to be merged.