### PR TITLE
fix: Disable C runtime static linking on aarch64-unknown-linux-musl

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.x86_64-unknown-linux-musl]
 rustflags = "-Ctarget-feature=-crt-static"
+
+[target.aarch64-unknown-linux-musl]
+rustflags = "-Ctarget-feature=-crt-static"


### PR DESCRIPTION
[Without this options we cannot build a cdylib for aarch64-unknown-linux-musl.](https://github.com/eclipse-zenoh/zenoh-plugin-webserver/actions/runs/8623964615/job/23638165112)