### PR TITLE
chore: renamed no_mangle feature to dynamic_plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ name = "zenoh_plugin_webserver"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["no_mangle"]
-no_mangle = []
+default = ["dynamic_plugin"]
+dynamic_plugin = []
 stats = ["zenoh/stats"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ impl Plugin for WebServerPlugin {
 
 impl RunningPluginTrait for WebServerPlugin {}
 
-#[cfg(feature = "no_mangle")]
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(WebServerPlugin);
 
 async fn run(runtime: Runtime, conf: Config) {


### PR DESCRIPTION
As suggested by @milyin this PR renames the `no_mangle` feature to `dynamic_plugin` which is easier to understand.
- Sister of: https://github.com/eclipse-zenoh/zenoh/pull/1010