### PR TITLE
Use `spawn_runtime` instead of `tokio::task::spawn` in `handle_request`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ async fn handle_request(req: Request<Arc<Session>>) -> tide::Result<Response> {
                 tracing::debug!("Subscribe to {} for Multipart stream", selector.key_expr());
                 let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
                 let c_selector = selector.key_expr().clone().into_owned();
-                tokio::task::spawn(async move {
+                spawn_runtime(async move {
                     tracing::debug!("Subscribe to {} for Multipart stream", c_selector);
                     let sub = req.state().declare_subscriber(c_selector).await.unwrap();
                     loop {


### PR DESCRIPTION
Fixes https://github.com/eclipse-zenoh/zenoh-plugin-webserver/issues/211.