### PR TITLE
Bump Rust toolchain to 1.85

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.85.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ fn default_max_block_thread_num() -> usize {
 
 struct HttpPortVisitor;
 
-impl<'de> Visitor<'de> for HttpPortVisitor {
+impl Visitor<'_> for HttpPortVisitor {
     type Value = String;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Depends on https://github.com/eclipse-zenoh/zenoh/pull/1803